### PR TITLE
Optimize lightbox caption handlers and enable mobile zoom

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,6 +21,8 @@ export const metadata: Metadata = {
 export const viewport = {
   width: "device-width",
   initialScale: 1,
+  maximumScale: 5,
+  userScalable: true,
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import {
   ChangeEvent,
   CSSProperties,
   KeyboardEvent,
+  useCallback,
 } from "react";
 import {
   Card,
@@ -134,17 +135,20 @@ export default function HomePage() {
     }
   }, [messages]);
 
-  const toggleCaption = () =>
-    setIsCaptionExpanded((prev) => !prev);
+  const toggleCaption = useCallback(
+    () => setIsCaptionExpanded((prev) => !prev),
+    []
+  );
 
-  const handleCaptionKeyDown = (
-    event: KeyboardEvent<HTMLDivElement>
-  ) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      toggleCaption();
-    }
-  };
+  const handleCaptionKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        toggleCaption();
+      }
+    },
+    [toggleCaption]
+  );
 
   const handleGenerateImage = async () => {
     if (!finalPrompt) {
@@ -379,7 +383,7 @@ export default function HomePage() {
                 style={
                   isCaptionExpanded
                     ? captionContainerStyle
-                    : { ...captionContainerStyle, maxHeight: "4.5em" }
+                    : collapsedCaptionContainerStyle
                 }
               >
                 <span style={captionTextStyle}>


### PR DESCRIPTION
## Summary
- memoize lightbox caption handlers with `useCallback`
- reuse collapsed caption style constant to avoid extra allocations
- allow pinch-zoom on mobile by permitting user scaling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0c3cffba48333a86fd161fe5b1292