### PR TITLE
Enable lightbox pinch zoom and memoize slide renderer

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -156,7 +156,7 @@ export default function HomePage() {
       <div style={slideContainerStyle}>
         <img
           src={slide.src}
-          alt={history[lightboxIndex]?.prompt}
+          alt={history[index]?.prompt}
           style={slideImageStyle}
         />
         <div

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,6 +30,7 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Loader2, PlusCircle } from "lucide-react";
 import Lightbox from "yet-another-react-lightbox";
+import Zoom from "yet-another-react-lightbox/plugins/zoom";
 import "yet-another-react-lightbox/styles.css";
 
 const slideContainerStyle: CSSProperties = {
@@ -148,6 +149,46 @@ export default function HomePage() {
       }
     },
     [toggleCaption]
+  );
+
+  const renderSlide = useCallback(
+    ({ slide }: { slide: { src: string } }) => (
+      <div style={slideContainerStyle}>
+        <img
+          src={slide.src}
+          alt={history[lightboxIndex]?.prompt}
+          style={slideImageStyle}
+        />
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={toggleCaption}
+          onKeyDown={handleCaptionKeyDown}
+          style={
+            isCaptionExpanded
+              ? captionContainerStyle
+              : collapsedCaptionContainerStyle
+          }
+        >
+          <span style={captionTextStyle}>
+            {history[lightboxIndex]?.prompt}
+          </span>
+          {!isCaptionExpanded && (
+            <>
+              <div style={captionGradientStyle} />
+              <span style={moreTextStyle}>more...</span>
+            </>
+          )}
+        </div>
+      </div>
+    ),
+    [
+      history,
+      lightboxIndex,
+      isCaptionExpanded,
+      toggleCaption,
+      handleCaptionKeyDown,
+    ]
   );
 
   const handleGenerateImage = async () => {
@@ -367,38 +408,8 @@ export default function HomePage() {
         styles={{ container: { backgroundColor: "rgba(0, 0, 0, .9)" } }}
         animation={{ swipe: 0, fade: 0 }}
         carousel={{ finite: true }}
-        render={{
-          slide: ({ slide }) => (
-            <div style={slideContainerStyle}>
-              <img
-                src={slide.src}
-                alt={history[lightboxIndex]?.prompt}
-                style={slideImageStyle}
-              />
-              <div
-                role="button"
-                tabIndex={0}
-                onClick={toggleCaption}
-                onKeyDown={handleCaptionKeyDown}
-                style={
-                  isCaptionExpanded
-                    ? captionContainerStyle
-                    : collapsedCaptionContainerStyle
-                }
-              >
-                <span style={captionTextStyle}>
-                  {history[lightboxIndex]?.prompt}
-                </span>
-                {!isCaptionExpanded && (
-                  <>
-                    <div style={captionGradientStyle} />
-                    <span style={moreTextStyle}>more...</span>
-                  </>
-                )}
-              </div>
-            </div>
-          ),
-        }}
+        render={{ slide: renderSlide }}
+        plugins={[Zoom]}
       />
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -152,7 +152,7 @@ export default function HomePage() {
   );
 
   const renderSlide = useCallback(
-    ({ slide }: { slide: { src: string } }) => (
+    ({ slide, index }: { slide: { src: string }; index: number }) => (
       <div style={slideContainerStyle}>
         <img
           src={slide.src}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -171,7 +171,7 @@ export default function HomePage() {
           }
         >
           <span style={captionTextStyle}>
-            {history[lightboxIndex]?.prompt}
+            {history[index]?.prompt}
           </span>
           {!isCaptionExpanded && (
             <>


### PR DESCRIPTION
## Summary
- add Zoom plugin to allow pinch-zoom in lightbox
- memoize slide rendering with `useCallback`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0c62af93883338c803bee395e56b3